### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.3 to 4.0.4

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,11 +19,14 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 version.com.uchuhimo..konf-yaml=0.22.1
 
 version.io.github.classgraph..classgraph=4.8.72
+##                           # available=4.8.75
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.3
+version.io.kotest..kotest-assertions-core-jvm=4.0.4
 
 version.io.kotest..kotest-property-jvm=4.0.3
+##                         # available=4.0.4
 
 version.io.kotest..kotest-runner-junit5-jvm=4.0.3
+##                              # available=4.0.4
 
 version.kotlin=1.3.50


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.