### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.4 to 4.0.5

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,9 +19,9 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 version.com.uchuhimo..konf-yaml=0.22.1
 
 version.io.github.classgraph..classgraph=4.8.75
+##                           # available=4.8.77
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.4
-##                                # available=4.0.5
+version.io.kotest..kotest-assertions-core-jvm=4.0.5
 
 version.io.kotest..kotest-property-jvm=4.0.4
 ##                         # available=4.0.5


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.