### PR TITLE
Upgrade classgraph from 4.8.83 to 4.8.84

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -18,7 +18,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.com.uchuhimo..konf-yaml=0.22.1
 
-version.io.github.classgraph..classgraph=4.8.83
+version.io.github.classgraph..classgraph=4.8.84
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.