### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.6 to 4.1.0.RC1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,7 +20,7 @@ version.com.uchuhimo..konf-yaml=0.22.1
 
 version.io.github.classgraph..classgraph=4.8.85
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.6
+version.io.kotest..kotest-assertions-core-jvm=4.1.0.RC1
 
 version.io.kotest..kotest-property-jvm=4.0.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.