### PR TITLE
Upgrade kotest-runner-junit5-jvm from 4.1.0.RC1 to 4.1.0.RC2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -24,6 +24,6 @@ version.io.kotest..kotest-assertions-core-jvm=4.1.0.RC2
 
 version.io.kotest..kotest-property-jvm=4.1.0.RC2
 
-version.io.kotest..kotest-runner-junit5-jvm=4.1.0.RC1
+version.io.kotest..kotest-runner-junit5-jvm=4.1.0.RC2
 
 version.kotlin=1.3.50


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.