### PR TITLE
Upgrade kotest from 4.2.0.RC2 to 4.2.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,6 +20,6 @@ version.com.uchuhimo..konf-yaml=0.22.1
 
 version.io.github.classgraph..classgraph=4.8.87
 
-version.kotest=4.2.0.RC2
+version.kotest=4.2.0
 
 version.kotlin=1.3.50


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.