### PR TITLE
Upgrade kotlin from 1.3.61 to 1.3.70

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,4 +23,4 @@ version.io.github.classgraph..classgraph=4.8.89
 
 version.kotest=4.2.3
 
-version.kotlin=1.3.61
+version.kotlin=1.3.70


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.