### PR TITLE
Upgrade kotest from 4.2.5 to 4.2.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version..konf=0.22.1
 
 version.io.github.classgraph..classgraph=4.8.90
 
-version.kotest=4.2.5
+version.kotest=4.2.6
 
 version.kotlin=1.3.72


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.