### PR TITLE
Upgrade classgraph from 4.8.95 to 4.8.96

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version..konf=0.22.1
 
-version.io.github.classgraph..classgraph=4.8.95
+version.io.github.classgraph..classgraph=4.8.96
 
 version.kotest=4.1.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.