### PR TITLE
Upgrade classgraph from 4.8.98 to 4.8.100

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version..konf=1.0.0
 
-version.io.github.classgraph..classgraph=4.8.98
+version.io.github.classgraph..classgraph=4.8.100
 
 version.kotest=4.3.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.