### PR TITLE
Upgrade Gradle Wrapper to 7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project 
from 7.0.1 to 7.1.                       