### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version..konf=1.1.2
 
 version.io.github.classgraph..classgraph=4.8.110
 
-version.kotest=4.5.0
+version.kotest=4.6.1
 
 version.kotlin=1.4.32


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.