### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 gitSemVer {
-    version = computeGitSemVer().replace("+", "-")
+    buildMetadataSeparator.set("-")
 }
 
 group = "org.danilopianini"

--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@ plugin.com.gradle.plugin-publish=0.15.0
 
 plugin.io.gitlab.arturbosch.detekt=1.17.1
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.